### PR TITLE
Anonymize OsmMapReader sql query

### DIFF
--- a/src/AppComponents/Common/Filter/OsmMapReader.cpp
+++ b/src/AppComponents/Common/Filter/OsmMapReader.cpp
@@ -364,8 +364,8 @@ bool OsmMapReader::operator()(
             and ST_DWithin( ST_Transform( ST_GeomFromText( $1, 4326 ), 32632 ), line.way, $2 )
         )sql"};
     boost::replace_all(query, "$HIGHWAY_CONDITION", toHighwaySelectionSql(highwaySelection_, "line"));
-    dbConnection->prepare("wayquery", query);
-    pqxx::result records = dbTransaction.exec_prepared("wayquery", pointsString, searchRadius);
+    dbConnection->prepare("", query);
+    pqxx::result records = dbTransaction.exec_prepared("", pointsString, searchRadius);
 
     APP_LOG_TAG_MS(noise, "DB") << records.size() << " records were read";
 


### PR DESCRIPTION
The prepared statement can only be initialized ones, multiple calls
throw an exception. By anonymizing the query, it can be initialized
multiple times.