### PR TITLE
Fix last occurence of `if( j.at( "type" ) != "Point" )`.

### DIFF
--- a/src/Core/Common/Geometry/Conversion.cpp
+++ b/src/Core/Common/Geometry/Conversion.cpp
@@ -30,7 +30,7 @@ nlohmann::json toGeoJson(Point const & point)
 
 LineString toLineString(nlohmann::json const & geoJson)
 {
-    if (geoJson.at("type") != "LineString")
+    if (geoJson.at("type").get<std::string>() != "LineString")
         throw std::runtime_error("GeoJson type is not LineString");
     LineString lineString;
     for (auto const & coordinate : geoJson.at("coordinates"))


### PR DESCRIPTION

Closes [os-matcher-amb#39](https://gl.ambrosys.de/os-matcher/os-matcher/-/issues/39).