### PR TITLE
Update ColumnLimit to 120

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,7 +54,7 @@ BreakConstructorInitializersBeforeComma: false  # deprecated
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: false
-ColumnLimit:     180
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false


### PR DESCRIPTION
A ColumnLimit of 180 is far to big. 
- Definitions in Headers or method calls with several parameters with several non trivial types get over that fast.
- horizontal scrolling is a pain
- Not everybody has an 2k or 4k monitor (me) but just HD (me and others) some have on their Laptop even smaller resolutions, due to the small screens, if no monitor is available (not me, but I know colleagues) this is however a minority.   
- Our python format definition is 111.   

But it seems that this option shall be as big as possible. 

Compromise: On a HD monitor in standard font size in several IDEs in default window/widget configuration (VS code, Intellij) the line ends between Column 120 and 130.  
So I propose a ColumnLimit of 120.